### PR TITLE
Add Roblox GUI Maker tool guide

### DIFF
--- a/tools/roblox-gui-maker.md
+++ b/tools/roblox-gui-maker.md
@@ -1,0 +1,59 @@
+---
+title: "Roblox GUI Maker"
+description: "AI-assisted Roblox Studio GUI planner for ScreenGui layouts, HUDs, menus, and Lua starter code ideas."
+category: "tools"
+tags: ["roblox", "roblox-studio", "gui-maker", "lua", "game-ui", "ai-tool"]
+tech_stack: ["roblox-studio", "lua", "luau", "ui-design"]
+---
+
+### Tool Benefits
+- **Roblox-first UI planning**: Turn a short description into a ScreenGui-oriented interface plan for HUDs, menus, shops, inventories, admin panels, and mobile-first Roblox screens.
+- **Component hierarchy drafts**: Get a structured starting point for frames, buttons, labels, scrolling areas, layout constraints, and responsive Roblox Studio UI decisions.
+- **Lua starter ideas**: Use the generated Lua and Luau-oriented notes as a first pass before implementing and testing the interface manually in Roblox Studio.
+- **Prototype speed**: Move faster from idea to usable game UI direction without starting every screen from a blank canvas.
+
+### Setup & Installation
+1. **Open the Web Tool**:
+   - Visit [Roblox GUI Maker](https://robloxguimaker.dev/) in your browser.
+2. **Describe the Interface**:
+   - Enter the Roblox UI you want to plan, such as a shop menu, inventory screen, onboarding popup, admin panel, or combat HUD.
+3. **Review the Output**:
+   - Use the generated layout plan, JSON-style blueprint, export checklist, and Lua starter code ideas as implementation guidance inside Roblox Studio.
+
+### Configuration
+- **Target Screen Type**:
+  - Decide whether the UI is for desktop, mobile, or both before generating the plan.
+- **Roblox Studio Constraints**:
+  - Check anchor points, scale versus offset usage, safe areas, and responsive layout details before building the final ScreenGui.
+- **Script Scope**:
+  - Treat generated Lua snippets as starting points. Review and adapt scripts for your own services, events, and game-specific state.
+
+### Usage Guide
+- **Planning a Shop UI**:
+  - Ask for a shop interface with item cards, price labels, preview panels, and purchase buttons.
+- **Designing a HUD**:
+  - Describe health, stamina, currency, quest progress, and mobile action buttons so the tool can suggest a ScreenGui hierarchy.
+- **Creating an Admin Panel**:
+  - Request tabs, player lists, action buttons, confirmation states, and access-control notes before implementing the panel in Studio.
+
+### Advanced Features
+- **JSON Blueprint Thinking**:
+  - Use structured output to map UI sections into Roblox Studio instances.
+- **Export Checklist**:
+  - Follow the checklist to verify naming, layout, scaling, scripting hooks, and mobile readability.
+- **Iteration Workflow**:
+  - Generate multiple variants for the same screen, then merge the strongest layout decisions manually.
+
+### Troubleshooting
+- **Layout Feels Too Dense**:
+  - Regenerate with a stricter mobile-first prompt and ask for fewer primary controls.
+- **Lua Needs Game Context**:
+  - Replace placeholder events, services, and state names with the real systems used by your Roblox experience.
+- **Studio Result Looks Different**:
+  - Recheck scale, offset, anchor point, and UIConstraint settings after translating the plan into actual Roblox instances.
+
+### Best Practices
+- **Prototype Before Polishing**: Build a quick Roblox Studio version first, then tune spacing, animations, and visual style.
+- **Name Instances Clearly**: Use predictable names for frames, buttons, and scripts so future edits stay manageable.
+- **Test on Mobile Early**: Roblox players often use mobile devices, so verify touch targets and safe areas before finalizing.
+- **Keep Generated Code Reviewed**: Treat all AI-generated Lua as draft code that needs testing, security review, and game-specific integration.


### PR DESCRIPTION
Adds a tool guide for Roblox GUI Maker.\n\nRoblox GUI Maker is a free AI-assisted browser tool for Roblox Studio creators planning ScreenGui layouts, HUDs, menus, mobile UI, and Lua starter-code ideas. The guide follows the existing frontmatter and section structure used by the tools directory.